### PR TITLE
update source code link from nextjs/examples to datocms/nextjs-demo

### DIFF
--- a/components/alert.js
+++ b/components/alert.js
@@ -27,7 +27,7 @@ export default function Alert({ preview }) {
             <>
               The source code for this blog is{' '}
               <a
-                href={`https://github.com/zeit/next.js/tree/canary/examples/${EXAMPLE_PATH}`}
+                href={`https://github.com/datocms/nextjs-demo`}
                 className="underline hover:text-success duration-200 transition-colors"
               >
                 available on GitHub


### PR DESCRIPTION
the link at the top of the demo page links to github/nextjs/examples, but the actual code in use is github/datocms/nextjs-demo. While they are almost identical, there are some differences, so it might be better to link to this repo instead of the nextjs demo.

![image](https://user-images.githubusercontent.com/580312/84366699-7c4b9a00-abd3-11ea-84ec-cc62f2f3e34f.png)
