### PR TITLE
Fix post detail

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -60,7 +60,7 @@ export async function getPreviewPostBySlug(slug) {
 }
 
 export async function getAllPostsWithSlug() {
-  const data = fetchAPI(`
+  const data = await fetchAPI(`
     {
       allPosts {
         slug

--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -50,7 +50,7 @@ export default function Post({ post, morePosts, preview }) {
   )
 }
 
-export async function getStaticProps({ params, preview }) {
+export async function getStaticProps({ params, preview = false }) {
   const data = await getPostAndMorePosts(params.slug, preview)
   const content = await markdownToHtml(data?.post?.content || '')
 


### PR DESCRIPTION
when running the example (`yarn dev`) the posts/[slug].js page threw errors. 
The [next.js dato cms demo](github.com/vercel/next.js/blob/canary/examples/cms-datocms) runs without problems.

I fixed the example by changing 2 things:

1. `await` of fetchApi inside getAllPostsWithSlug 

```
Unhandled Runtime Error Error: Failed to load static props)
```

![image](https://user-images.githubusercontent.com/580312/84367870-1cee8980-abd5-11ea-9bd1-31d6d87ec753.png)

Not sure why this does work for the [nextjs demo](https://github.com/vercel/next.js/blob/canary/examples/cms-datocms/lib/api.js#L61)

2. default `false` value of getStaticProps.
```
Error: Error serializing `.preview` returned from `getStaticProps` in "/posts/[slug]". 
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value all together.
```

![image](https://user-images.githubusercontent.com/580312/84367929-3394e080-abd5-11ea-9e2d-3a965665b660.png)

This has already been fixed in https://github.com/vercel/next.js/blob/canary/examples/cms-datocms/pages/posts/%5Bslug%5D.js#L53
