### PR TITLE
`preview` is undefined in `Post`

### DIFF
--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -105,6 +105,7 @@ export async function getStaticProps({ params, preview = false }) {
             enabled: false,
             initialData: await request(graphqlRequest),
           },
+      preview,
     },
   };
 }


### PR DESCRIPTION
This is a bug which makes it impossible to test the real time preview mode on blog posts.