### PR TITLE
Add Next.js revalidation so posts update correctly

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -47,7 +47,7 @@ const PAGE_CONTENT_QUERY = `
 function getPageRequest() {
   const { isEnabled } = draftMode();
 
-  return { query: PAGE_CONTENT_QUERY, includeDrafts: isEnabled };
+  return { query: PAGE_CONTENT_QUERY, includeDrafts: isEnabled, revalidate: 1 };
 }
 
 export async function generateMetadata() {

--- a/app/posts/[slug]/page.js
+++ b/app/posts/[slug]/page.js
@@ -87,7 +87,7 @@ const PAGE_CONTENT_QUERY = `
 function getPageRequest(slug) {
   const { isEnabled } = draftMode();
 
-  return { query: PAGE_CONTENT_QUERY, includeDrafts: isEnabled, variables: { slug } };
+  return { query: PAGE_CONTENT_QUERY, includeDrafts: isEnabled, variables: { slug }, revalidate: 1 };
 }
 
 export async function generateMetadata({ params }) {


### PR DESCRIPTION
It looks to me like the blog post wasn't getting correctly updated even after publishing & rebuilding, possibly due to the [Next.js data cache](https://nextjs.org/docs/app/building-your-application/caching#data-cache).

All tests were done in new Incognito windows, with preview mode OFF.

## Before
https://github.com/datocms/nextjs-demo/assets/11964962/9699903b-67a6-4267-b4fc-732a4c02ec47

## After
Adding `revalidate: 1` (in seconds) to our default fetchers seems to fix that for me.

![image](https://github.com/datocms/nextjs-demo/assets/11964962/f67c5b24-8eeb-4d9b-94a4-3efe19a7695b)

![image](https://github.com/datocms/nextjs-demo/assets/11964962/019e32a7-b7ab-4459-ad7a-a71fb03894a1)
